### PR TITLE
Add configuration pulled from YAML file

### DIFF
--- a/configuration/config.go
+++ b/configuration/config.go
@@ -13,12 +13,3 @@ type Rule struct {
 	Debounce int    `yaml:"debounce"`
 	Command  string `yaml:"command"`
 }
-
-func (c *Config) Test() *Rule {
-	for _, rule := range c.Rules {
-		if rule.Name == "Test" {
-			return &rule
-		}
-	}
-	panic("Must have a rule named Test")
-}

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -1,0 +1,24 @@
+package configuration
+
+type Config struct {
+	Build string `yaml:"build"`
+	Run   string `yaml:"run"`
+	Rules []Rule `yaml:"rules"`
+}
+
+type Rule struct {
+	Name     string `yaml:"name"`
+	Regex    string `yaml:"regex"`
+	Ignore   string `yaml:"ignore"`
+	Debounce int    `yaml:"debounce"`
+	Command  string `yaml:"command"`
+}
+
+func (c *Config) Test() *Rule {
+	for _, rule := range c.Rules {
+		if rule.Name == "Test" {
+			return &rule
+		}
+	}
+	panic("Must have a rule named Test")
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/rafaelsq/wtc
 
 go 1.13
 
-require github.com/rjeczalik/notify v0.9.2
+require (
+	github.com/rjeczalik/notify v0.9.2
+	gopkg.in/yaml.v2 v2.2.4
+)

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,6 @@ github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7 h1:bit1t3mgdR35yN0cX0G8orgLtOuyL9Wqxa1mccLB0ig=
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
fixes #1 

This is a very simple first step.  I stripped the `go build` off of the build command in the configuration YAML to keep it consistent with passing those hard-coded to `run`.  I also made the `Test` rule a required thing in the configuration to keep that task around.  It could definitely be enhanced further.