### PR TITLE
Fix: Changing MIT license badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Actions Status](https://github.com/rafaelsq/wtc/workflows/tests/badge.svg)](https://github.com/rafaelsq/wtc/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rafaelsq/wtc)](https://goreportcard.com/report/github.com/rafaelsq/wtc)
 [![GoDoc](https://godoc.org/github.com/rafaelsq/wtc?status.svg)](https://godoc.org/github.com/rafaelsq/wtc)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/rafaelsq/wtc/blob/master/LICENSE)
 
 **Watch is a simple watch files utility**  
 You can use it to watch files and run any command.  


### PR DESCRIPTION
As requested, the MIT badge link was changed
from : https://opensource.org/licenses/MIT
to :  https://github.com/rafaelsq/wtc/blob/master/LICENSE

Fixes #9 