### PR TITLE
deps: update go version and change CI Lint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,18 +5,20 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.17
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
           path: go/src/github.com/rafaelsq/wtc
-      - name: GolangCI-Lint
-        run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.19.1
-          ./bin/golangci-lint run
       - name: Test
         run: go test -race -cover ./...
+      - name: GolangCI-Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          skip-build-cache: true
+          skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,12 @@ linters:
     - revive
     - exportloopref
     - unparam
+    - gocritic
+    - staticcheck
+    - gosec
+    - errcheck
+    - prealloc
+    - ineffassign
 
 linters-settings:
   lll:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+run:
+  timeout: 1m
+
+linters:
+  enable:
+    - lll
+    - gofmt
+    - revive
+    - exportloopref
+    - unparam
+
+linters-settings:
+  lll:
+    line-length: 130

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ WTC is a simple utility you can use to watch files and execute commands.
 ## Install
 
 From master branch  
-`$ go get -u github.com/rafaelsq/wtc`  
+`$ go install github.com/rafaelsq/wtc@latest`  
 
 You can also install by release(linux64 only);  
 `$ curl -sfL --silent https://github.com/rafaelsq/wtc/releases/latest/download/wtc.linux64.tar.gz | tar -xzv && mv wtc $(go env GOPATH)/bin/`
@@ -29,12 +29,12 @@ Before you begin, ensure you have installed the latest version of Go. See the [G
 $ wtc --help
 USAGE:
 wtc [[flags] [regex command]]
-        ex.: wtc
+        e.g.: wtc
             // will read [.]wtc.y[a]ml
-        ex.: wtc "_test\.go$" "go test -cover {PKG}"
+        e.g.: wtc "_test\.go$" "go test -cover {PKG}"
 
 wtc [flags]] [rule-name]
-        ex.: wtc -t rule-name
+        e.g.: wtc -t rule-name
              wtc --no-trace "rule ruleb"
 FLAGS:
   -debounce int
@@ -47,7 +47,7 @@ FLAGS:
         disable messages.
   -t string
         trig one or more rules by name
-                ex.: wtc -t ruleA
+                e.g.: wtc -t ruleA
                      wtc -t "ruleA ruleB"
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rafaelsq/wtc
 
-go 1.13
+go 1.17
 
 require (
 	github.com/creack/pty v1.1.11

--- a/pkg/wtc/wtc.go
+++ b/pkg/wtc/wtc.go
@@ -106,15 +106,20 @@ func ParseArgs() *Config {
 
 	flag.Parse()
 
-	if has, err := readConfig(config, configFilePath); err != nil {
+	ok, err := readConfig(config, configFilePath)
+	if err != nil {
 		log.Fatal(err)
-	} else if has && flag.NArg() == 1 {
+	}
+
+	if ok && flag.NArg() == 1 {
 		trigs = flag.Arg(0)
-	} else if !has && flag.NArg() < 2 {
-		_, _ = fmt.Fprintf(os.Stderr, "No [.]wtc.yaml or valid command provided.\n")
-		flag.CommandLine.Usage()
-		os.Exit(1)
-	} else if !has {
+	} else {
+		if flag.NArg() < 2 {
+			_, _ = fmt.Fprintf(os.Stderr, "No [.]wtc.yaml or valid command provided.\n")
+			flag.CommandLine.Usage()
+			os.Exit(2)
+		}
+
 		config.Rules = append(config.Rules, &Rule{
 			Name:    "run",
 			Match:   flag.Arg(0),
@@ -460,7 +465,7 @@ func trig(rule *Rule, pkg, path string) error {
 	case <-time.After(time.Duration(debounce) * time.Millisecond):
 	}
 
-	cmd := strings.Replace(strings.Replace(rule.Command, "{PKG}", pkg, -1), "{FILE}", path, -1)
+	cmd := strings.ReplaceAll(strings.ReplaceAll(rule.Command, "{PKG}", pkg), "{FILE}", path)
 
 	keys := map[string]string{}
 	envs := os.Environ()

--- a/pkg/wtc/wtc.go
+++ b/pkg/wtc/wtc.go
@@ -84,9 +84,9 @@ func ParseArgs() *Config {
 		fmt.Fprintf(
 			flag.CommandLine.Output(),
 			"USAGE:\nwtc [[flags] [regex command]]\n"+
-				"\tex.: wtc\n\t    // will read [.]wtc.y[a]ml\n"+
-				"\tex.: wtc \"_test\\.go$\" \"go test -cover {PKG}\"\n\n"+
-				"wtc [flags]] [rule-name]\n\tex.: wtc -t rule-name\n\t     wtc --no-trace \"rule ruleb\"\n"+
+				"\te.g.: wtc\n\t    // will read [.]wtc.y[a]ml\n"+
+				"\te.g.: wtc \"_test\\.go$\" \"go test -cover {PKG}\"\n\n"+
+				"wtc [flags]] [rule-name]\n\te.g.: wtc -t rule-name\n\t     wtc --no-trace \"rule ruleb\"\n"+
 				"FLAGS:\n",
 		)
 		flag.PrintDefaults()
@@ -102,7 +102,7 @@ func ParseArgs() *Config {
 	flag.StringVar(&configFilePath, "f", "", "wtc config file (default try to find [.]wtc.y[a]ml)")
 
 	var trigs string
-	flag.StringVar(&trigs, "t", "", "trig one or more rules by name\n\tex.: wtc -t ruleA\n\t     wtc -t \"ruleA ruleB\"")
+	flag.StringVar(&trigs, "t", "", "trig one or more rules by name\n\te.g.: wtc -t ruleA\n\t     wtc -t \"ruleA ruleB\"")
 
 	flag.Parse()
 
@@ -181,6 +181,9 @@ func Start(cfg *Config) {
 				// close current
 				if currentOut != nil {
 					_, err = (*currentOut).Write(currentArgs[1])
+					if err != nil {
+						log.Println(err)
+					}
 				}
 
 				// parse tpl
@@ -208,6 +211,9 @@ func Start(cfg *Config) {
 
 				// write start
 				_, err = currentOut.Write(currentArgs[0])
+				if err != nil {
+					log.Println(err)
+				}
 			}
 
 			if r.Rune == 0 || r.Rune == BR {
@@ -215,6 +221,9 @@ func Start(cfg *Config) {
 			}
 
 			_, err = fmt.Fprintf(currentOut, "%c", r.Rune)
+			if err != nil {
+				log.Println(err)
+			}
 		}
 	}()
 
@@ -462,20 +471,20 @@ func trig(rule *Rule, pkg, path string) error {
 	for _, e := range append(config.Env, rule.Env...) {
 		if strings.ToLower(e.Type) == "file" {
 			if e.Name == "" {
-				panic(fmt.Errorf("field \"name\" must point to a file"))
+				log.Fatal("field \"name\" must point to a file")
 			}
 
 			var body string
 			{
 				fileInfo, err := os.Stat(e.Name)
 				if err != nil {
-					panic(err)
+					log.Fatal(err)
 				}
 
 				if lastModified, ok := envFileLastModified[e.Name]; !ok || fileInfo.ModTime().Sub(lastModified) > 0 {
 					b, err := ioutil.ReadFile(e.Name)
 					if err != nil {
-						panic(err)
+						log.Fatal(err)
 					}
 
 					envFileKeys[e.Name] = string(b)


### PR DESCRIPTION
- Update go to 1.17
- Replace Golang-CI Lint step with the [official action](https://github.com/golangci/golangci-lint-action) 
- Replace `ex` by `e.g.` (Ex exists only in PT)
- Small fixes in logs and panics.
- `go get` deprecated, after 1.17 Go recommends `go install` for binaries
- Shell recommends `exit 2` for validation error - https://tldp.org/LDP/abs/html/exitcodes.html